### PR TITLE
Fix test flakiness by serializing PersistenceManager tests

### DIFF
--- a/increment/IncrementProject/IncrementPackage/Tests/IncrementFeatureTests/PersistenceManagerTests.swift
+++ b/increment/IncrementProject/IncrementPackage/Tests/IncrementFeatureTests/PersistenceManagerTests.swift
@@ -13,7 +13,7 @@ import Foundation
  * when the app closes or device restarts.
  */
 
-@Suite("PersistenceManager Tests")
+@Suite("PersistenceManager Tests", .serialized)
 struct PersistenceManagerTests {
 
     init() async {


### PR DESCRIPTION
## Summary

Fixes the test flakiness where `testSaveLoadExerciseStates()` was failing intermittently in CI (failed 5 times in [run #18172367453](https://github.com/ishandhanani/misc/actions/runs/18172367453)).

## Root Cause

Swift Testing runs tests in parallel by default. All tests in `PersistenceManagerTests` share:
- `UserDefaults.standard` 
- `PersistenceManager.shared` singleton

When tests ran concurrently, they interfered with each other:
1. Test A calls `clearAll()` and saves data
2. Test B simultaneously calls `clearAll()`, wiping Test A's data  
3. Test A tries to load data and finds nothing or wrong data
4. Test fails intermittently

The `clearAll()` calls in the suite's `init()` and each test weren't sufficient because they created race conditions between parallel tests.

## Solution

Added `.serialized` trait to the test suite to force sequential execution:

```swift
@Suite("PersistenceManager Tests", .serialized)
struct PersistenceManagerTests {
```

This ensures:
- Tests can't interfere with each other's UserDefaults data
- The `clearAll()` calls properly isolate each test
- Tests are deterministic and won't be flaky

## Testing

The fix should eliminate the intermittent failures. CI will validate this works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)