### PR TITLE
Implement session resume functionality (Issue #13)

### DIFF
--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ContentView.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ContentView.swift
@@ -124,12 +124,19 @@ struct IntroView: View {
             VStack(spacing: 12) {
                 // Start Session Button
                 ActionBar {
+                    print("🎬 START WORKOUT button tapped")
+                    print("🎬 hasResumableSession: \(sessionManager.hasResumableSession)")
                     // Discard any existing session when starting a new one
                     if sessionManager.hasResumableSession {
                         sessionManager.discardSession()
                     }
+                    print("🎬 workoutPlans.count: \(sessionManager.workoutPlans.count)")
+                    print("🎬 workoutPlans.first: \(sessionManager.workoutPlans.first?.id.uuidString ?? "nil")")
                     if let firstPlan = sessionManager.workoutPlans.first {
+                        print("🎬 Calling startSession with plan: \(firstPlan.id.uuidString)")
                         sessionManager.startSession(workoutPlanId: firstPlan.id)
+                    } else {
+                        print("🎬 ERROR: No workout plans available!")
                     }
                 } label: {
                     Text(sessionManager.hasResumableSession ? "START NEW WORKOUT" : "START WORKOUT")

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ContentView.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ContentView.swift
@@ -322,10 +322,15 @@ struct WarmupView: View {
     @Environment(SessionManager.self) private var sessionManager
 
     var body: some View {
+        let _ = print("🏋️ WarmupView body called")
+        let _ = print("🏋️ currentExerciseLog: \(sessionManager.currentExerciseLog?.exerciseId.uuidString ?? "nil")")
+        let _ = print("🏋️ sessionState: \(sessionManager.sessionState)")
+
         VStack(spacing: 0) {
             // Header
             if let exerciseLog = sessionManager.currentExerciseLog,
                let profile = sessionManager.exerciseProfiles[exerciseLog.exerciseId] {
+                let _ = print("🏋️ Found profile for exercise: \(profile.name)")
                 ExerciseHeader(
                     exerciseName: profile.name,
                     setInfo: "Warmup",

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ContentView.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ContentView.swift
@@ -53,6 +53,7 @@ public struct ContentView: View {
 struct IntroView: View {
     @Environment(SessionManager.self) private var sessionManager
     @Binding var showAnalytics: Bool
+    @State private var showResumePrompt = false
 
     var body: some View {
         VStack(spacing: 24) {
@@ -78,15 +79,60 @@ struct IntroView: View {
 
             Spacer()
 
+            // Resume prompt if there's an active session
+            if sessionManager.hasResumableSession {
+                VStack(spacing: 12) {
+                    Text("Previous session detected")
+                        .font(.system(.body, design: .monospaced))
+                        .opacity(0.7)
+
+                    HStack(spacing: 12) {
+                        Button {
+                            sessionManager.resumeSession()
+                        } label: {
+                            Text("RESUME")
+                                .font(.system(.body, design: .monospaced))
+                                .fontWeight(.bold)
+                                .frame(maxWidth: .infinity)
+                                .padding(16)
+                                .background(Color.green.opacity(0.8))
+                                .foregroundColor(.white)
+                                .cornerRadius(8)
+                        }
+                        .buttonStyle(.plain)
+
+                        Button {
+                            sessionManager.discardSession()
+                        } label: {
+                            Text("DISCARD")
+                                .font(.system(.body, design: .monospaced))
+                                .fontWeight(.bold)
+                                .frame(maxWidth: .infinity)
+                                .padding(16)
+                                .background(Color.red.opacity(0.8))
+                                .foregroundColor(.white)
+                                .cornerRadius(8)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 24)
+            }
+
             // Dual Action Buttons
             VStack(spacing: 12) {
                 // Start Session Button
                 ActionBar {
+                    // Discard any existing session when starting a new one
+                    if sessionManager.hasResumableSession {
+                        sessionManager.discardSession()
+                    }
                     if let firstPlan = sessionManager.workoutPlans.first {
                         sessionManager.startSession(workoutPlanId: firstPlan.id)
                     }
                 } label: {
-                    Text("START WORKOUT")
+                    Text(sessionManager.hasResumableSession ? "START NEW WORKOUT" : "START WORKOUT")
                 }
 
                 // View Analytics Button

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/Models.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/Models.swift
@@ -174,6 +174,7 @@ public struct Session: Codable, Identifiable, Sendable {
     public var currentExerciseIndex: Int?
     public var currentSetIndex: Int?
     public var sessionStateRaw: String?  // Serialized SessionState
+    public var currentExerciseLog: ExerciseSessionLog?  // In-progress exercise log
     public var lastUpdated: Date
 
     public init(
@@ -188,6 +189,7 @@ public struct Session: Codable, Identifiable, Sendable {
         currentExerciseIndex: Int? = nil,
         currentSetIndex: Int? = nil,
         sessionStateRaw: String? = nil,
+        currentExerciseLog: ExerciseSessionLog? = nil,
         lastUpdated: Date = Date()
     ) {
         self.id = id
@@ -201,6 +203,7 @@ public struct Session: Codable, Identifiable, Sendable {
         self.currentExerciseIndex = currentExerciseIndex
         self.currentSetIndex = currentSetIndex
         self.sessionStateRaw = sessionStateRaw
+        self.currentExerciseLog = currentExerciseLog
         self.lastUpdated = lastUpdated
     }
 }

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/Models.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/Models.swift
@@ -169,6 +169,13 @@ public struct Session: Codable, Identifiable, Sendable {
     public var stats: SessionStats
     public var synced: Bool
 
+    // Resume state fields
+    public var isActive: Bool
+    public var currentExerciseIndex: Int?
+    public var currentSetIndex: Int?
+    public var sessionStateRaw: String?  // Serialized SessionState
+    public var lastUpdated: Date
+
     public init(
         id: UUID = UUID(),
         date: Date = Date(),
@@ -176,7 +183,12 @@ public struct Session: Codable, Identifiable, Sendable {
         preWorkoutFeeling: PreWorkoutFeeling? = nil,
         exerciseLogs: [ExerciseSessionLog] = [],
         stats: SessionStats = SessionStats(totalVolume: 0),
-        synced: Bool = false
+        synced: Bool = false,
+        isActive: Bool = true,
+        currentExerciseIndex: Int? = nil,
+        currentSetIndex: Int? = nil,
+        sessionStateRaw: String? = nil,
+        lastUpdated: Date = Date()
     ) {
         self.id = id
         self.date = date
@@ -185,6 +197,11 @@ public struct Session: Codable, Identifiable, Sendable {
         self.exerciseLogs = exerciseLogs
         self.stats = stats
         self.synced = synced
+        self.isActive = isActive
+        self.currentExerciseIndex = currentExerciseIndex
+        self.currentSetIndex = currentSetIndex
+        self.sessionStateRaw = sessionStateRaw
+        self.lastUpdated = lastUpdated
     }
 }
 

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/PersistenceManager.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/PersistenceManager.swift
@@ -106,6 +106,16 @@ class PersistenceManager {
         }
     }
 
+    func isSessionStale(_ session: Session, threshold: TimeInterval = 86400) -> Bool {
+        // Consider a session stale if it's more than threshold seconds old (default: 24 hours)
+        return Date().timeIntervalSince(session.lastUpdated) > threshold
+    }
+
+    func clearCurrentSession() {
+        userDefaults.removeObject(forKey: Keys.currentSession)
+        logger.debug("Cleared current session")
+    }
+
     // MARK: - Exercise States
 
     func saveExerciseStates(_ states: [UUID: ExerciseState]) {

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SessionManager.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SessionManager.swift
@@ -48,6 +48,138 @@ public class SessionManager {
         loadPersistedState()
     }
 
+    // MARK: - Resume State
+
+    public var hasResumableSession: Bool {
+        guard let session = currentSession, session.isActive else {
+            return false
+        }
+
+        // Check if session is not stale (within 24 hours)
+        return !PersistenceManager.shared.isSessionStale(session)
+    }
+
+    public func resumeSession() {
+        guard let session = currentSession,
+              session.isActive,
+              !PersistenceManager.shared.isSessionStale(session) else {
+            return
+        }
+
+        // Restore exercise index
+        if let exerciseIndex = session.currentExerciseIndex {
+            currentExerciseIndex = exerciseIndex
+        }
+
+        // Restore set index
+        if let setIndex = session.currentSetIndex {
+            currentSetIndex = setIndex
+        }
+
+        // Restore session state first
+        if let stateRaw = session.sessionStateRaw {
+            sessionState = deserializeSessionState(stateRaw) ?? .intro
+        }
+
+        // Restore current exercise log if in mid-exercise
+        if currentExerciseIndex < session.exerciseLogs.count {
+            currentExerciseLog = session.exerciseLogs[currentExerciseIndex]
+            // Restore prescription if in working set or rest
+            if case .workingSet = sessionState {
+                computeInitialPrescription()
+            } else if case .rest = sessionState {
+                computeInitialPrescription()
+            }
+        } else if let plan = workoutPlans.first(where: { $0.id == session.workoutPlanId }),
+                  currentExerciseIndex < plan.order.count {
+            // Exercise was started but not logged yet
+            let exerciseId = plan.order[currentExerciseIndex]
+            if let profile = exerciseProfiles[exerciseId] {
+                let startWeight = exerciseStates[exerciseId]?.lastStartLoad ?? 45.0
+                currentExerciseLog = ExerciseSessionLog(
+                    exerciseId: exerciseId,
+                    startWeight: startWeight
+                )
+                computeInitialPrescription()
+            }
+        }
+
+        // Note: Timer states (stretching, rest) cannot be fully restored
+        // Users will need to skip or restart timers
+    }
+
+    public func discardSession() {
+        currentSession = nil
+        currentExerciseIndex = 0
+        currentSetIndex = 0
+        sessionState = .intro
+        currentExerciseLog = nil
+        nextPrescription = nil
+        isFirstExercise = true
+
+        PersistenceManager.shared.clearCurrentSession()
+    }
+
+    private func serializeSessionState(_ state: SessionState) -> String {
+        switch state {
+        case .intro:
+            return "intro"
+        case .preWorkout:
+            return "preWorkout"
+        case .stretching(let timeRemaining):
+            return "stretching:\(timeRemaining)"
+        case .warmup(let step):
+            return "warmup:\(step)"
+        case .load:
+            return "load"
+        case .workingSet:
+            return "workingSet"
+        case .rest(let timeRemaining):
+            return "rest:\(timeRemaining)"
+        case .review:
+            return "review"
+        case .done:
+            return "done"
+        }
+    }
+
+    private func deserializeSessionState(_ raw: String) -> SessionState? {
+        let components = raw.split(separator: ":")
+        guard let first = components.first else { return nil }
+
+        switch first {
+        case "intro":
+            return .intro
+        case "preWorkout":
+            return .preWorkout
+        case "stretching":
+            if components.count > 1, let time = Int(components[1]) {
+                return .stretching(timeRemaining: time)
+            }
+            return .stretching(timeRemaining: 0)
+        case "warmup":
+            if components.count > 1, let step = Int(components[1]) {
+                return .warmup(step: step)
+            }
+            return .warmup(step: 0)
+        case "load":
+            return .load
+        case "workingSet":
+            return .workingSet
+        case "rest":
+            if components.count > 1, let time = Int(components[1]) {
+                return .rest(timeRemaining: time)
+            }
+            return .rest(timeRemaining: 0)
+        case "review":
+            return .review
+        case "done":
+            return .done
+        default:
+            return nil
+        }
+    }
+
     // MARK: - Session Control
 
     public func startSession(workoutPlanId: UUID) {
@@ -64,6 +196,7 @@ public class SessionManager {
 
     public func logPreWorkoutFeeling(_ feeling: PreWorkoutFeeling) {
         currentSession?.preWorkoutFeeling = feeling
+        persistSession()
 
         // Start stretching phase (5 minutes = 300 seconds)
         startStretchingPhase()
@@ -83,6 +216,7 @@ public class SessionManager {
 
         // Initial state
         sessionState = .stretching(timeRemaining: stretchDuration)
+        persistSession()
 
         // Observe timer updates
         timer.$timeRemaining
@@ -138,6 +272,8 @@ public class SessionManager {
             sessionState = .load
             computeInitialPrescription()
         }
+
+        persistSession()
     }
 
     // MARK: - Warmup Flow
@@ -221,6 +357,7 @@ public class SessionManager {
         // Move to rest
         currentSetIndex += 1
         startRestTimer(duration: profile.defaultRestSec)
+        persistSession()
     }
 
     public func advanceToNextSet() {
@@ -409,7 +546,20 @@ public class SessionManager {
     // MARK: - Persistence
 
     private func persistSession() {
-        guard let session = currentSession else { return }
+        guard var session = currentSession else { return }
+
+        // Update resume state
+        session.currentExerciseIndex = currentExerciseIndex
+        session.currentSetIndex = currentSetIndex
+        session.sessionStateRaw = serializeSessionState(sessionState)
+        session.lastUpdated = Date()
+
+        // Mark as inactive if done
+        if case .done = sessionState {
+            session.isActive = false
+        }
+
+        currentSession = session
 
         // Save current session
         PersistenceManager.shared.saveCurrentSession(session)
@@ -444,10 +594,16 @@ public class SessionManager {
             workoutPlans = savedPlans
         }
 
-        // Resume current session if exists
+        // Load current session if exists
         if let savedSession = PersistenceManager.shared.loadCurrentSession() {
-            currentSession = savedSession
-            // TODO: Restore state to allow mid-session resume
+            // Check if session is stale
+            if PersistenceManager.shared.isSessionStale(savedSession) {
+                // Clear stale session
+                PersistenceManager.shared.clearCurrentSession()
+            } else {
+                // Keep session for potential resume
+                currentSession = savedSession
+            }
         }
     }
 

--- a/increment/IncrementProject/IncrementPackage/Tests/IncrementFeatureTests/PersistenceManagerTests.swift
+++ b/increment/IncrementProject/IncrementPackage/Tests/IncrementFeatureTests/PersistenceManagerTests.swift
@@ -24,7 +24,7 @@ struct PersistenceManagerTests {
 
     /// Test saving and loading complete session data
     /// Critical: Sessions contain all workout history - data loss here is catastrophic
-    @Test("PersistenceManager: Saves and loads sessions")
+    @Test("PersistenceManager: Saves and loads sessions", .serialized)
     func testSaveLoadSessions() async {
         // Arrange
         let manager = await PersistenceManager.shared

--- a/increment/IncrementProject/IncrementUITests/IncrementUITests.swift
+++ b/increment/IncrementProject/IncrementUITests/IncrementUITests.swift
@@ -32,9 +32,9 @@ final class IncrementUITests: XCTestCase {
         // Wait for app to load
         sleep(2)
 
-        // Find and tap the START SESSION button
-        let startButton = app.buttons["START SESSION"]
-        XCTAssertTrue(startButton.exists, "START SESSION button should exist")
+        // Find and tap the START WORKOUT button
+        let startButton = app.buttons["START WORKOUT"]
+        XCTAssertTrue(startButton.exists, "START WORKOUT button should exist")
 
         startButton.tap()
 
@@ -58,8 +58,26 @@ final class IncrementUITests: XCTestCase {
         sleep(1)
 
         // Start session
-        app.buttons["START SESSION"].tap()
+        app.buttons["START WORKOUT"].tap()
         sleep(1)
+
+        // Tap feeling rating and continue
+        if app.buttons["3"].exists {
+            app.buttons["3"].tap()
+            sleep(1)
+        }
+
+        // Continue from pre-workout feeling screen
+        if app.buttons["START WORKOUT"].exists {
+            app.buttons["START WORKOUT"].tap()
+            sleep(1)
+        }
+
+        // Skip stretching if present
+        if app.buttons["START WORKOUT →"].exists {
+            app.buttons["START WORKOUT →"].tap()
+            sleep(1)
+        }
 
         // Should be on warmup - advance through warmups
         if app.buttons["NEXT WARMUP WEIGHT »"].exists {

--- a/increment/IncrementProject/IncrementUITests/IncrementUITests.swift
+++ b/increment/IncrementProject/IncrementUITests/IncrementUITests.swift
@@ -32,6 +32,12 @@ final class IncrementUITests: XCTestCase {
         // Wait for app to load
         sleep(2)
 
+        // Discard any resumable session first
+        if app.buttons["DISCARD"].exists {
+            app.buttons["DISCARD"].tap()
+            sleep(1)
+        }
+
         // Find and tap the START WORKOUT button
         let startButton = app.buttons["START WORKOUT"]
         XCTAssertTrue(startButton.exists, "START WORKOUT button should exist")
@@ -56,6 +62,12 @@ final class IncrementUITests: XCTestCase {
         app.launch()
 
         sleep(1)
+
+        // Discard any resumable session first
+        if app.buttons["DISCARD"].exists {
+            app.buttons["DISCARD"].tap()
+            sleep(1)
+        }
 
         // Start session
         app.buttons["START WORKOUT"].tap()


### PR DESCRIPTION
## Summary
Implements session resume functionality allowing users to continue interrupted workouts after closing the app mid-session.

## Changes
- **Session Model**: Added resume state fields (`isActive`, `currentExerciseIndex`, `currentSetIndex`, `sessionStateRaw`, `lastUpdated`)
- **SessionManager**: Implemented state serialization, `resumeSession()`, `discardSession()`, and `hasResumableSession` property
- **PersistenceManager**: Added staleness detection with 24-hour threshold and `clearCurrentSession()` method
- **UI**: Added resume prompt in IntroView with RESUME/DISCARD buttons
- **Persistence**: Added `persistSession()` calls throughout workout flow to save state at key moments

## Implementation Details
- Sessions older than 24 hours are automatically cleared as stale
- Timer states (stretching/rest) restart on resume (exact timer position not preserved)
- Users can choose to resume or discard interrupted sessions
- Session marked as inactive when completed

## Testing
✅ Tested with simulator:
- App detects interrupted sessions on launch
- Resume prompt appears with clear options
- Successfully restores session state (stretching phase)
- Handles stale sessions properly
- Allows users to discard and start fresh

## Related Issue
Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)