### PR TITLE
Refactor Analytics and Settings UI

### DIFF
--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/AnalyticsView.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/AnalyticsView.swift
@@ -180,25 +180,26 @@ struct StatCard: View {
     let value: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 16) {
             Text(title)
                 .font(.system(.caption, design: .monospaced))
-                .foregroundColor(.white.opacity(0.6))
+                .foregroundColor(.white.opacity(0.7))
+                .textCase(.uppercase)
 
             Text(value)
-                .font(.system(.title3, design: .monospaced))
+                .font(.system(.title2, design: .monospaced))
                 .fontWeight(.bold)
                 .foregroundColor(.white)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(20)
+        .padding(24)
         .background(
-            RoundedRectangle(cornerRadius: 4)
-                .fill(Color.white.opacity(0.03))
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.white.opacity(0.04))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 4)
-                .stroke(Color.white.opacity(0.15), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.white.opacity(0.2), lineWidth: 1)
         )
     }
 }
@@ -219,61 +220,65 @@ struct RecentTrendChart: View {
                 EmptyChartMessageView(message: "No workout data yet")
             } else {
                 Chart(trend) { dataPoint in
-                    LineMark(
-                        x: .value("Date", dataPoint.date),
-                        y: .value("Volume", dataPoint.volume)
-                    )
-                    .foregroundStyle(.white)
-                    .lineStyle(StrokeStyle(lineWidth: 3))
-                    .interpolationMethod(.catmullRom)
-
                     AreaMark(
                         x: .value("Date", dataPoint.date),
                         y: .value("Volume", dataPoint.volume)
                     )
                     .foregroundStyle(
                         LinearGradient(
-                            colors: [.white.opacity(0.3), .white.opacity(0.05)],
+                            colors: [Color.cyan.opacity(0.4), Color.cyan.opacity(0.05)],
                             startPoint: .top,
                             endPoint: .bottom
                         )
                     )
                     .interpolationMethod(.catmullRom)
 
+                    LineMark(
+                        x: .value("Date", dataPoint.date),
+                        y: .value("Volume", dataPoint.volume)
+                    )
+                    .foregroundStyle(Color.cyan)
+                    .lineStyle(StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
+                    .interpolationMethod(.catmullRom)
+
                     PointMark(
                         x: .value("Date", dataPoint.date),
                         y: .value("Volume", dataPoint.volume)
                     )
-                    .foregroundStyle(.white)
-                    .symbolSize(50)
+                    .foregroundStyle(Color.cyan)
+                    .symbolSize(60)
                 }
                 .chartXAxis {
                     AxisMarks(values: .automatic(desiredCount: 5)) { _ in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                            .foregroundStyle(.white.opacity(0.1))
                         AxisValueLabel()
-                            .foregroundStyle(.white.opacity(0.5))
+                            .foregroundStyle(.white.opacity(0.6))
                             .font(.system(.caption2, design: .monospaced))
                     }
                 }
                 .chartYAxis {
                     AxisMarks(position: .leading) { value in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                            .foregroundStyle(.white.opacity(0.1))
                         AxisValueLabel {
                             if let volume = value.as(Double.self) {
                                 Text(formatVolume(volume))
                                     .font(.system(.caption2, design: .monospaced))
                             }
                         }
-                        .foregroundStyle(.white.opacity(0.5))
+                        .foregroundStyle(.white.opacity(0.6))
                     }
                 }
-                .frame(height: 200)
-                .padding(20)
+                .frame(height: 240)
+                .padding(24)
                 .background(
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color.white.opacity(0.03))
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.white.opacity(0.04))
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 4)
-                        .stroke(Color.white.opacity(0.15), lineWidth: 1)
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
                 )
             }
         }

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ContentView.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ContentView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 public struct ContentView: View {
     @Environment(SessionManager.self) private var sessionManager
     @State private var showingAnalytics = false
+    @State private var showingSettings = false
 
     public init() {}
 
@@ -13,7 +14,10 @@ public struct ContentView: View {
             Color(red: 0.1, green: 0.15, blue: 0.3)
                 .ignoresSafeArea()
 
-            if showingAnalytics {
+            if showingSettings {
+                // Settings View
+                SettingsView(isPresented: $showingSettings)
+            } else if showingAnalytics {
                 // Analytics View
                 AnalyticsView(isPresented: $showingAnalytics)
             } else {
@@ -22,7 +26,7 @@ public struct ContentView: View {
                     // Render appropriate view based on session state
                     switch sessionManager.sessionState {
                     case .intro:
-                        IntroView(showAnalytics: $showingAnalytics)
+                        IntroView(showAnalytics: $showingAnalytics, showSettings: $showingSettings)
                     case .preWorkout:
                         PreWorkoutView()
                     case .workoutOverview:

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ExerciseProgressView.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ExerciseProgressView.swift
@@ -118,7 +118,7 @@ struct ProgressionChart: View {
                     )
                     .foregroundStyle(
                         LinearGradient(
-                            colors: [.white.opacity(0.15), .white.opacity(0.02)],
+                            colors: [Color.purple.opacity(0.35), Color.purple.opacity(0.05)],
                             startPoint: .top,
                             endPoint: .bottom
                         )
@@ -130,8 +130,8 @@ struct ProgressionChart: View {
                         x: .value("Date", dataPoint.date),
                         y: .value("Weight", dataPoint.weight)
                     )
-                    .foregroundStyle(.white)
-                    .lineStyle(StrokeStyle(lineWidth: 2.5))
+                    .foregroundStyle(Color.purple.opacity(0.9))
+                    .lineStyle(StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
                     .interpolationMethod(.catmullRom)
 
                     // Points with decision colors
@@ -142,49 +142,57 @@ struct ProgressionChart: View {
                     .foregroundStyle(colorForDecision(dataPoint.decision))
                     .symbolSize(
                         selectedDate != nil && Calendar.current.isDate(dataPoint.date, inSameDayAs: selectedDate!)
-                            ? 120
-                            : 70
+                            ? 140
+                            : 80
                     )
 
-                    // Selection indicator
+                    // Selection indicator ring
                     if let selectedDate = selectedDate,
                        Calendar.current.isDate(dataPoint.date, inSameDayAs: selectedDate) {
                         PointMark(
                             x: .value("Date", dataPoint.date),
                             y: .value("Weight", dataPoint.weight)
                         )
-                        .foregroundStyle(.white)
-                        .symbolSize(40)
+                        .foregroundStyle(.clear)
+                        .symbolSize(180)
+                        .symbol {
+                            Circle()
+                                .strokeBorder(Color.white.opacity(0.5), lineWidth: 2)
+                        }
                     }
                 }
                 .chartXSelection(value: $selectedDate)
                 .chartXAxis {
                     AxisMarks(values: .automatic(desiredCount: 5)) { _ in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                            .foregroundStyle(.white.opacity(0.1))
                         AxisValueLabel()
-                            .foregroundStyle(.white.opacity(0.5))
+                            .foregroundStyle(.white.opacity(0.6))
                             .font(.system(.caption2, design: .monospaced))
                     }
                 }
                 .chartYAxis {
                     AxisMarks(position: .leading) { value in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                            .foregroundStyle(.white.opacity(0.1))
                         AxisValueLabel {
                             if let weight = value.as(Double.self) {
                                 Text("\(Int(weight)) lb")
                                     .font(.system(.caption2, design: .monospaced))
                             }
                         }
-                        .foregroundStyle(.white.opacity(0.5))
+                        .foregroundStyle(.white.opacity(0.6))
                     }
                 }
-                .frame(height: 220)
-                .padding(16)
+                .frame(height: 260)
+                .padding(20)
                 .background(
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color.white.opacity(0.03))
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.white.opacity(0.04))
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 4)
-                        .stroke(Color.white.opacity(0.15), lineWidth: 1)
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
                 )
 
                 // Selection details

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SettingsView.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SettingsView.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+
+// MARK: - Settings View
+
+@MainActor
+public struct SettingsView: View {
+    @Binding var isPresented: Bool
+    @AppStorage("restTimerSound") private var restTimerSound = true
+    @AppStorage("showWorkoutReminders") private var showWorkoutReminders = false
+
+    public init(isPresented: Binding<Bool>) {
+        self._isPresented = isPresented
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            // Header with back button
+            HStack {
+                Button {
+                    isPresented = false
+                } label: {
+                    HStack(spacing: 6) {
+                        Text("←")
+                            .font(.system(.body, design: .monospaced))
+                        Text("Back")
+                            .font(.system(.body, design: .monospaced))
+                    }
+                    .foregroundColor(.white.opacity(0.7))
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+
+                Text("SETTINGS")
+                    .font(.system(.title3, design: .monospaced))
+                    .fontWeight(.bold)
+                    .foregroundColor(.white)
+            }
+            .padding(20)
+            .background(Color.black.opacity(0.3))
+
+            // Settings Content
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    // Workout Settings Section
+                    SettingsSection(title: "WORKOUT") {
+                        SettingToggle(
+                            title: "Rest Timer Sound",
+                            description: "Play sound when rest timer completes",
+                            isOn: $restTimerSound
+                        )
+
+                        SettingToggle(
+                            title: "Workout Reminders",
+                            description: "Get notified to stay consistent",
+                            isOn: $showWorkoutReminders
+                        )
+                    }
+
+                    // About Section
+                    SettingsSection(title: "ABOUT") {
+                        SettingRow(
+                            title: "Version",
+                            value: "1.0.0"
+                        )
+
+                        SettingRow(
+                            title: "Build",
+                            value: "2025.1"
+                        )
+                    }
+                }
+                .padding(24)
+            }
+        }
+    }
+}
+
+// MARK: - Settings Section
+
+struct SettingsSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(title)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundColor(.white.opacity(0.7))
+                .textCase(.uppercase)
+
+            VStack(spacing: 0) {
+                content
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.white.opacity(0.04))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.white.opacity(0.2), lineWidth: 1)
+            )
+        }
+    }
+}
+
+// MARK: - Setting Toggle
+
+struct SettingToggle: View {
+    let title: String
+    let description: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(title)
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundColor(.white)
+
+                    Text(description)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.6))
+                }
+
+                Spacer()
+
+                Toggle("", isOn: $isOn)
+                    .labelsHidden()
+                    .tint(.cyan)
+            }
+            .padding(20)
+        }
+    }
+}
+
+// MARK: - Setting Row
+
+struct SettingRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.system(.body, design: .monospaced))
+                .foregroundColor(.white)
+
+            Spacer()
+
+            Text(value)
+                .font(.system(.body, design: .monospaced))
+                .foregroundColor(.white.opacity(0.7))
+        }
+        .padding(20)
+    }
+}

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/Views/IntroView.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/Views/IntroView.swift
@@ -5,28 +5,46 @@ import OSLog
 struct IntroView: View {
     @Environment(SessionManager.self) private var sessionManager
     @Binding var showAnalytics: Bool
+    @Binding var showSettings: Bool
     @State private var showResumePrompt = false
 
     var body: some View {
         VStack(spacing: 24) {
             Spacer()
 
-            // Terminal panel
-            VStack(alignment: .leading, spacing: 8) {
-                Text("INCREMENT")
-                    .font(.system(.largeTitle, design: .monospaced))
-                    .fontWeight(.bold)
+            // Terminal panel with settings button
+            VStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("INCREMENT")
+                                .font(.system(.largeTitle, design: .monospaced))
+                                .fontWeight(.bold)
 
-                Text("Terminal-inspired lifting tracker")
-                    .font(.system(.body, design: .monospaced))
-                    .opacity(0.7)
+                            Text("Terminal-inspired lifting tracker")
+                                .font(.system(.body, design: .monospaced))
+                                .opacity(0.7)
+                        }
+
+                        Spacer()
+
+                        Button {
+                            showSettings = true
+                        } label: {
+                            Text("⚙")
+                                .font(.system(.title2))
+                                .foregroundColor(.white.opacity(0.7))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(24)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                )
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(24)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color.white.opacity(0.2), lineWidth: 1)
-            )
             .padding(.horizontal, 24)
 
             Spacer()


### PR DESCRIPTION
## Background
This PR addresses UI polish for analytics and introduces a new Settings screen.

## Changes
- **`AnalyticsView.swift`**:
  - Enhanced `StatCard` appearance: increased padding, uppercase titles, larger value font size, rounded corners with better border.
  - Improved `RecentTrendChart`: Changed colors to cyan, increased height, added subtle grid lines, refined line styling, updated area gradient, larger point marks, 8pt corner radius on background.
- **`ExerciseProgressView.swift`**:
  - Refined `ProgressionChart`: Changed colors to purple, increased height, added subtle grid lines on both axes, improved gradient, updated selection indicator with a ring, increased point sizes, and applied 8pt corner radius to background.
- **`ContentView.swift`**:
  - Added `@State private var showingSettings` to manage the presentation of the SettingsView.
  - Modified `IntroView`'s state management to conditionally present `SettingsView` or `AnalyticsView`.
- **`SettingsView.swift`** (New File):
  - Implemented a new `SettingsView` with a terminal-style header and back button.
  - Includes `SettingsSection`, `SettingToggle`, and `SettingRow` reusable components.
  - Adds `restTimerSound` and `showWorkoutReminders` toggles using `@AppStorage`.
  - Includes "About" section with version and build information.
- **`IntroView.swift`**:
  - Added a settings gear icon (⚙) button that toggles the `showingSettings` state.
  - Updated the initializer to accept `showSettings` binding.
