### PR TITLE
Refactor charts and clean settings page

### DIFF
--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/AnalyticsView.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/AnalyticsView.swift
@@ -220,25 +220,12 @@ struct RecentTrendChart: View {
                 EmptyChartMessageView(message: "No workout data yet")
             } else {
                 Chart(trend) { dataPoint in
-                    AreaMark(
-                        x: .value("Date", dataPoint.date),
-                        y: .value("Volume", dataPoint.volume)
-                    )
-                    .foregroundStyle(
-                        LinearGradient(
-                            colors: [Color.cyan.opacity(0.4), Color.cyan.opacity(0.05)],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                    .interpolationMethod(.catmullRom)
-
                     LineMark(
                         x: .value("Date", dataPoint.date),
                         y: .value("Volume", dataPoint.volume)
                     )
                     .foregroundStyle(Color.cyan)
-                    .lineStyle(StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
+                    .lineStyle(StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round))
                     .interpolationMethod(.catmullRom)
 
                     PointMark(
@@ -246,39 +233,40 @@ struct RecentTrendChart: View {
                         y: .value("Volume", dataPoint.volume)
                     )
                     .foregroundStyle(Color.cyan)
-                    .symbolSize(60)
+                    .symbolSize(50)
                 }
+                .chartYScale(domain: 0...(trend.map { $0.volume }.max() ?? 100) * 1.1)
                 .chartXAxis {
                     AxisMarks(values: .automatic(desiredCount: 5)) { _ in
                         AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                            .foregroundStyle(.white.opacity(0.1))
+                            .foregroundStyle(.white.opacity(0.15))
                         AxisValueLabel()
-                            .foregroundStyle(.white.opacity(0.6))
+                            .foregroundStyle(.white.opacity(0.7))
                             .font(.system(.caption2, design: .monospaced))
                     }
                 }
                 .chartYAxis {
-                    AxisMarks(position: .leading) { value in
+                    AxisMarks(position: .leading, values: .automatic(desiredCount: 5)) { value in
                         AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                            .foregroundStyle(.white.opacity(0.1))
+                            .foregroundStyle(.white.opacity(0.15))
                         AxisValueLabel {
                             if let volume = value.as(Double.self) {
                                 Text(formatVolume(volume))
                                     .font(.system(.caption2, design: .monospaced))
                             }
                         }
-                        .foregroundStyle(.white.opacity(0.6))
+                        .foregroundStyle(.white.opacity(0.7))
                     }
                 }
-                .frame(height: 240)
-                .padding(24)
+                .frame(height: 260)
+                .padding(20)
                 .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.white.opacity(0.04))
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color.white.opacity(0.05))
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.white.opacity(0.15), lineWidth: 1)
                 )
             }
         }

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ExerciseProgressView.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/ExerciseProgressView.swift
@@ -109,29 +109,17 @@ struct ProgressionChart: View {
             if progression.isEmpty {
                 EmptyProgressionMessage()
             } else {
-                Chart(progression) { dataPoint in
-                    // Area fill under line
-                    AreaMark(
-                        x: .value("Date", dataPoint.date),
-                        yStart: .value("Min", progression.map { $0.weight }.min() ?? 0),
-                        yEnd: .value("Weight", dataPoint.weight)
-                    )
-                    .foregroundStyle(
-                        LinearGradient(
-                            colors: [Color.purple.opacity(0.35), Color.purple.opacity(0.05)],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                    .interpolationMethod(.catmullRom)
+                let minWeight = (progression.map { $0.weight }.min() ?? 0) * 0.9
+                let maxWeight = (progression.map { $0.weight }.max() ?? 100) * 1.05
 
+                Chart(progression) { dataPoint in
                     // Line
                     LineMark(
                         x: .value("Date", dataPoint.date),
                         y: .value("Weight", dataPoint.weight)
                     )
-                    .foregroundStyle(Color.purple.opacity(0.9))
-                    .lineStyle(StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
+                    .foregroundStyle(Color.purple)
+                    .lineStyle(StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round))
                     .interpolationMethod(.catmullRom)
 
                     // Points with decision colors
@@ -142,8 +130,8 @@ struct ProgressionChart: View {
                     .foregroundStyle(colorForDecision(dataPoint.decision))
                     .symbolSize(
                         selectedDate != nil && Calendar.current.isDate(dataPoint.date, inSameDayAs: selectedDate!)
-                            ? 140
-                            : 80
+                            ? 120
+                            : 70
                     )
 
                     // Selection indicator ring
@@ -154,45 +142,46 @@ struct ProgressionChart: View {
                             y: .value("Weight", dataPoint.weight)
                         )
                         .foregroundStyle(.clear)
-                        .symbolSize(180)
+                        .symbolSize(160)
                         .symbol {
                             Circle()
-                                .strokeBorder(Color.white.opacity(0.5), lineWidth: 2)
+                                .strokeBorder(Color.white.opacity(0.6), lineWidth: 2)
                         }
                     }
                 }
                 .chartXSelection(value: $selectedDate)
+                .chartYScale(domain: minWeight...maxWeight)
                 .chartXAxis {
                     AxisMarks(values: .automatic(desiredCount: 5)) { _ in
                         AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                            .foregroundStyle(.white.opacity(0.1))
+                            .foregroundStyle(.white.opacity(0.15))
                         AxisValueLabel()
-                            .foregroundStyle(.white.opacity(0.6))
+                            .foregroundStyle(.white.opacity(0.7))
                             .font(.system(.caption2, design: .monospaced))
                     }
                 }
                 .chartYAxis {
-                    AxisMarks(position: .leading) { value in
+                    AxisMarks(position: .leading, values: .automatic(desiredCount: 5)) { value in
                         AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                            .foregroundStyle(.white.opacity(0.1))
+                            .foregroundStyle(.white.opacity(0.15))
                         AxisValueLabel {
                             if let weight = value.as(Double.self) {
                                 Text("\(Int(weight)) lb")
                                     .font(.system(.caption2, design: .monospaced))
                             }
                         }
-                        .foregroundStyle(.white.opacity(0.6))
+                        .foregroundStyle(.white.opacity(0.7))
                     }
                 }
-                .frame(height: 260)
+                .frame(height: 280)
                 .padding(20)
                 .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.white.opacity(0.04))
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color.white.opacity(0.05))
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.white.opacity(0.15), lineWidth: 1)
                 )
 
                 // Selection details

--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SettingsView.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SettingsView.swift
@@ -5,8 +5,6 @@ import SwiftUI
 @MainActor
 public struct SettingsView: View {
     @Binding var isPresented: Bool
-    @AppStorage("restTimerSound") private var restTimerSound = true
-    @AppStorage("showWorkoutReminders") private var showWorkoutReminders = false
 
     public init(isPresented: Binding<Bool>) {
         self._isPresented = isPresented
@@ -42,21 +40,6 @@ public struct SettingsView: View {
             // Settings Content
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
-                    // Workout Settings Section
-                    SettingsSection(title: "WORKOUT") {
-                        SettingToggle(
-                            title: "Rest Timer Sound",
-                            description: "Play sound when rest timer completes",
-                            isOn: $restTimerSound
-                        )
-
-                        SettingToggle(
-                            title: "Workout Reminders",
-                            description: "Get notified to stay consistent",
-                            isOn: $showWorkoutReminders
-                        )
-                    }
-
                     // About Section
                     SettingsSection(title: "ABOUT") {
                         SettingRow(


### PR DESCRIPTION
## Background
User requested cleaner graph aesthetics by removing gradient fills and simplifying the settings page by removing workout toggles.

## Changes
- `AnalyticsView.swift`: Removed `AreaMark` and adjusted `LineMark` and `PointMark` styling.
- `ExerciseProgressView.swift`: Removed `AreaMark` and adjusted `LineMark` and `PointMark` styling.
- `SettingsView.swift`: Removed "WORKOUT" section and associated `@AppStorage` properties.

## Testing
- [ ] Verify charts display as clean line graphs without gradient fills.
- [ ] Verify settings page only shows the "ABOUT" section.
