### PR TITLE
Add functionality to clear all data

### DIFF
--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SessionManager.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SessionManager.swift
@@ -220,6 +220,39 @@ public class SessionManager {
         AppLogger.session.info("Session discarded, reset to intro")
     }
 
+    /// Reset all data and state to fresh app state (used when clearing all data)
+    public func resetToFreshState() {
+        AppLogger.session.notice("Resetting to fresh state")
+
+        // Stop any active timers
+        restTimer?.stop()
+        restTimer = nil
+        cancellables.removeAll()
+
+        // Clear all in-memory state
+        currentSession = nil
+        currentExerciseIndex = 0
+        currentSetIndex = 0
+        sessionState = .intro
+        currentExerciseLog = nil
+        nextPrescription = nil
+        isFirstExercise = true
+
+        // Clear exercise data
+        exerciseProfiles = [:]
+        exerciseStates = [:]
+
+        // Reset workout cycle
+        workoutCycle = nil
+        currentWorkoutTemplate = nil
+        suggestedWorkoutType = .push
+
+        // Reload default state
+        loadDefaultWorkoutCycle()
+
+        AppLogger.session.info("Reset to fresh state complete")
+    }
+
     private func serializeSessionState(_ state: SessionState) -> String {
         switch state {
         case .intro:


### PR DESCRIPTION
## Background
As requested, this PR adds a feature to clear all user data and reset the app to its initial fresh state.

## Changes
- **`increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SessionManager.swift`**:
    - Added a new public function `resetToFreshState()` to `SessionManager`.
    - This function stops timers, clears in-memory state (current session, exercise/set indices, logs, prescriptions, etc.), resets exercise data, and reloads the default workout cycle.
- **`increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SettingsView.swift`**:
    - Added a "DATA" section to the `SettingsView`.
    - Included a "Clear All Data" button which presents a confirmation alert.
    - The confirmation alert, when accepted, calls `PersistenceManager.shared.clearAll()` and then `sessionManager.resetToFreshState()`, and dismisses the settings view.

## Testing
- [ ] Navigate to Settings.
- [ ] Tap "Clear All Data".
- [ ] Confirm the action in the alert dialog.
- [ ] Verify that all previous data is gone and the app is in its initial state.
- [ ] Test cancelling the clear data confirmation.
