### PR TITLE
Fix Live Activity clearing on workout exit

### DIFF
--- a/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SessionManager.swift
+++ b/increment/IncrementProject/IncrementPackage/Sources/IncrementFeature/SessionManager.swift
@@ -208,6 +208,11 @@ public class SessionManager {
         // Clear database first (synchronously)
         PersistenceManager.shared.clearCurrentSessionSync()
 
+        // End Live Activity
+        Task {
+            await endLiveActivity()
+        }
+
         // Then clear in-memory state
         currentSession = nil
         currentExerciseIndex = 0
@@ -228,6 +233,11 @@ public class SessionManager {
         restTimer?.stop()
         restTimer = nil
         cancellables.removeAll()
+
+        // End Live Activity
+        Task {
+            await endLiveActivity()
+        }
 
         // Clear all in-memory state
         currentSession = nil
@@ -364,6 +374,12 @@ public class SessionManager {
     /// Cancel workout selection - go back to intro with no DB changes
     public func cancelWorkoutSelection() {
         AppLogger.session.debug("Cancelled workout selection")
+
+        // End Live Activity if one is active
+        Task {
+            await endLiveActivity()
+        }
+
         sessionState = .intro
     }
 


### PR DESCRIPTION
## Background
Live Activities were not being cleared on the lock screen and Dynamic Island when users exited workouts through certain paths, leading to stale data being displayed.

## Changes
- Modified `SessionManager.swift` to include `Task { await endLiveActivity() }` calls in the following methods:
  - `discardSession()`: Ensures Live Activity ends when a user discards an in-progress workout.
  - `resetToFreshState()`: Ensures Live Activity ends when all app data is cleared from settings.
  - `cancelWorkoutSelection()`: Ensures Live Activity ends when a user cancels workout selection and returns to the intro screen.

## Testing
- [ ] Verify Live Activity ends when discarding a workout.
- [ ] Verify Live Activity ends when cancelling workout selection.
- [ ] Verify Live Activity ends when clearing app data from settings.
